### PR TITLE
Delete unused and non-existing import

### DIFF
--- a/tests/lava/tutorials/test_tutorials.py
+++ b/tests/lava/tutorials/test_tutorials.py
@@ -17,7 +17,6 @@ from test import support
 import nbformat
 
 import lava.lib.dnf
-import tutorials.lava.lib.dnf
 
 
 class TestTutorials(unittest.TestCase):


### PR DESCRIPTION
Fixes
```
ImportError: Failed to import test module: tests.lava.tutorials.test_tutorials Traceback (most recent call last):
  File "/home/conda/feedstock_root/build_artifacts/lava-dnf_1667299607137/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib/python3.10/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/home/conda/feedstock_root/build_artifacts/lava-dnf_1667299607137/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib/python3.10/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/home/conda/feedstock_root/build_artifacts/lava-dnf_1667299607137/test_tmp/tests/lava/tutorials/test_tutorials.py", line 20, in <module>
    import tutorials.lava.lib.dnf
ModuleNotFoundError: No module named 'tutorials'
```